### PR TITLE
Bugfixing + improved documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,9 @@ venv.bak/
 .spyderproject
 .spyproject
 
+# pycharm project settings
+.idea
+
 # Rope project settings
 .ropeproject
 

--- a/npxcompress/cli.py
+++ b/npxcompress/cli.py
@@ -26,13 +26,14 @@ def run_compression(root_dir: str, dry_run: bool):
             dtype=dtype,
             check_after_compress=True,
         )
-        status = "OK" if compressed_ok else "Failed"
-        bg_color = "green" if compressed_ok else "red"
+        status, bg_color = get_status_and_color(compressed_ok, dry_run)
         click.echo(f"Compress {bin_file}" + "... " + click.style(status, bg=bg_color))
-
-        deleted_ok = run_and_get_status(delete_files, dry_run, files=(bin_file,))
-        status, bg_color = get_status_and_color(deleted_ok)
-        click.echo(f"\tRAW files deleted... " + click.style(status, bg=bg_color))
+        if compressed_ok and not dry_run:
+            deleted_ok = run_and_get_status(delete_files, dry_run, files=(bin_file,))
+            status, bg_color = get_status_and_color(deleted_ok)
+            click.echo(f"\tRAW files deleted... " + click.style(status, bg=bg_color))
+        else:
+            click.echo("\tRAW files not deleted")
 
 
 def run_decompression(root_dir: str, dry_run: bool):
@@ -43,15 +44,18 @@ def run_decompression(root_dir: str, dry_run: bool):
     for bin_file, metadata_file in zip(bin_files, metadata_files):
         output_name = bin_file.parent / f"{bin_file.stem}.bin"
 
-        decompress_ok = run_and_get_status(
+        decompressed_ok = run_and_get_status(
             decompress, dry_run, cdata=str(bin_file), cmeta=str(metadata_file), out=str(output_name), check_after_decompress=True
         )
-        status, bg_color = get_status_and_color(decompress_ok)
+        status, bg_color = get_status_and_color(decompressed_ok, dry_run)
         click.echo(f"Decompress {bin_file}" + "... " + click.style(status, bg=bg_color))
 
-        deleted_ok = run_and_get_status(delete_files, dry_run, files=(bin_file, metadata_file))
-        status, bg_colors = get_status_and_color(deleted_ok)
-        click.echo(f"\tCompressed files deleted... " + click.style(status, bg=bg_color))
+        if decompressed_ok and not dry_run:
+            deleted_ok = run_and_get_status(delete_files, dry_run, files=(bin_file, metadata_file))
+            status, bg_colors = get_status_and_color(deleted_ok)
+            click.echo(f"\tCompressed files deleted... " + click.style(status, bg=bg_color))
+        else:
+            click.echo("\tCompressed files not deleted")
 
 
 @click.command()

--- a/npxcompress/cli.py
+++ b/npxcompress/cli.py
@@ -5,7 +5,7 @@ from npxcompress.sglx_utils import get_num_saved_channels, get_sample_rate, read
 from npxcompress.utils import delete_files, find_pairs, get_status_and_color, run_and_get_status
 
 
-def run_compression(root_dir: str, dry_run: bool):
+def run_compression(root_dir: str, dry_run: bool, keep_original: bool):
     click.echo(f"Starting to compress files found under {root_dir}")
     bin_files, metadata_files = find_pairs(root_dir)
     click.echo(f"Number of bin/meta pairs: {len(bin_files)}")
@@ -28,15 +28,16 @@ def run_compression(root_dir: str, dry_run: bool):
         )
         status, bg_color = get_status_and_color(compressed_ok, dry_run)
         click.echo(f"Compress {bin_file}" + "... " + click.style(status, bg=bg_color))
-        if compressed_ok and not dry_run:
+        if compressed_ok and not dry_run and not keep_original:
             deleted_ok = run_and_get_status(delete_files, dry_run, files=(bin_file,))
             status, bg_color = get_status_and_color(deleted_ok)
-            click.echo(f"\tRAW files deleted... " + click.style(status, bg=bg_color))
         else:
-            click.echo("\tRAW files not deleted")
+            status, bg_color = get_status_and_color(False, True)
+        click.echo(f"\tRAW files deleted... " + click.style(status, bg=bg_color))
+    return
 
 
-def run_decompression(root_dir: str, dry_run: bool):
+def run_decompression(root_dir: str, dry_run: bool, keep_original: bool):
     click.echo(f"Starting to decompress files found under {root_dir}")
     bin_files, metadata_files = find_pairs(root_dir, bin_ext="cbin", meta_ext="ch")
     click.echo(f"Number of bin/meta pairs: {len(bin_files)}")
@@ -50,12 +51,13 @@ def run_decompression(root_dir: str, dry_run: bool):
         status, bg_color = get_status_and_color(decompressed_ok, dry_run)
         click.echo(f"Decompress {bin_file}" + "... " + click.style(status, bg=bg_color))
 
-        if decompressed_ok and not dry_run:
+        if decompressed_ok and not dry_run and not keep_original:
             deleted_ok = run_and_get_status(delete_files, dry_run, files=(bin_file, metadata_file))
             status, bg_colors = get_status_and_color(deleted_ok)
-            click.echo(f"\tCompressed files deleted... " + click.style(status, bg=bg_color))
         else:
-            click.echo("\tCompressed files not deleted")
+            status, bg_color = get_status_and_color(False, True)
+        click.echo(f"\tCompressed files deleted... " + click.style(status, bg=bg_color))
+    return
 
 
 @click.command()
@@ -73,16 +75,23 @@ def run_decompression(root_dir: str, dry_run: bool):
     is_flag=True,
     help="Perform a dry-run, no compression or decompression will be performed.",
 )
-def main(root_dir: str, decompress: bool, dry_run: bool):
+@click.option(
+    "-k",
+    "--keep-original",
+    default=False,
+    is_flag=True,
+    help="Keep the source files after compression/decompression (otherwise deleted by default).",
+)
+def main(root_dir: str, decompress: bool, dry_run: bool, keep_original: bool):
     """Compress/decompress all bin files in a directory tree
 
     ROOT_DIR is the path from which the script will start looking for .(c)bin files. The script will traverse all folders
     starting from ROOT_DIR, find all .(c)bin/.(c)meta files and compress or decompress them.
     """
     if decompress:
-        run_decompression(root_dir, dry_run)
+        run_decompression(root_dir, dry_run, keep_original)
     else:
-        run_compression(root_dir, dry_run)
+        run_compression(root_dir, dry_run, keep_original)
 
 
 if __name__ == "__main__":

--- a/npxcompress/cli.py
+++ b/npxcompress/cli.py
@@ -29,9 +29,16 @@ def run_compression(root_dir: str, dry_run: bool, keep_original: bool):
         status, bg_color = get_status_and_color(compressed_ok, dry_run)
         click.echo(f"Compress {bin_file}" + "... " + click.style(status, bg=bg_color))
         if compressed_ok and not dry_run and not keep_original:
+            # Everything went correctly, go ahead and delete the raw files
             deleted_ok = run_and_get_status(delete_files, dry_run, files=(bin_file,))
             status, bg_color = get_status_and_color(deleted_ok)
+        elif not compressed_ok and not dry_run:
+            # Something went wrong with compression and not because of being a dry-run.
+            # Clean up the (broken) compressed file
+            _ = run_and_get_status(delete_files, dry_run, files=(bin_file.with_suffix(".cbin"),))
+            status, bg_color = get_status_and_color(False, True)
         else:
+            # Compression worked but either a dry-run, or keeping the original files
             status, bg_color = get_status_and_color(False, True)
         click.echo(f"\tRAW files deleted... " + click.style(status, bg=bg_color))
     return
@@ -52,8 +59,14 @@ def run_decompression(root_dir: str, dry_run: bool, keep_original: bool):
         click.echo(f"Decompress {bin_file}" + "... " + click.style(status, bg=bg_color))
 
         if decompressed_ok and not dry_run and not keep_original:
+            # Everything went correctly, go ahead and delete the compressed files
             deleted_ok = run_and_get_status(delete_files, dry_run, files=(bin_file, metadata_file))
             status, bg_colors = get_status_and_color(deleted_ok)
+        elif not decompressed_ok and not dry_run:
+            # Something went wrong with decompression and not because of being a dry-run.
+            # Clean up the (broken) decompressed file
+            _ = run_and_get_status(delete_files, dry_run, files=(output_name,))
+            status, bg_color = get_status_and_color(False, True)
         else:
             status, bg_color = get_status_and_color(False, True)
         click.echo(f"\tCompressed files deleted... " + click.style(status, bg=bg_color))

--- a/npxcompress/cli.py
+++ b/npxcompress/cli.py
@@ -61,14 +61,12 @@ def run_decompression(root_dir: str, dry_run: bool):
     "--decompress",
     default=False,
     is_flag=True,
-    flag_value=False,
     help="Whether to decompress files instead of compressing them.",
 )
 @click.option(
     "--dry-run",
     default=False,
     is_flag=True,
-    flag_value=False,
     help="Perform a dry-run, no compression or decompression will be performed.",
 )
 def main(root_dir: str, decompress: bool, dry_run: bool):

--- a/npxcompress/utils.py
+++ b/npxcompress/utils.py
@@ -20,9 +20,13 @@ def find_pairs(root_dir: str, bin_ext: str = "bin", meta_ext: str = "meta") -> T
     return bin_files, metadata_files
 
 
-def get_status_and_color(flag: bool) -> Tuple[str, str]:
-    status = "OK" if flag else "Failed"
-    bg_color = "green" if flag else "red"
+def get_status_and_color(flag: bool, skip: bool = False) -> Tuple[str, str]:
+    if skip:
+        status = "Skipped"
+        bg_color = "yellow"
+    else:
+        status = "OK" if flag else "Failed"
+        bg_color = "green" if flag else "red"
 
     return status, bg_color
 
@@ -31,9 +35,7 @@ def run_and_get_status(func: Callable[..., int], dry_run: bool, **kwargs) -> boo
     run_ok = True
     try:
         if dry_run:
-            shall_fail = decision(0.8)
-            if shall_fail:
-                raise Exception("fail")
+            raise Exception("Dry run")
         else:
             func(**kwargs)
     except:

--- a/readme_developers.md
+++ b/readme_developers.md
@@ -1,0 +1,73 @@
+## Developers
+
+## Docker
+
+```
+# Build image with (use whatever tag name you want)
+docker build -t npx .
+# Run tool via:
+docker run --rm npx --help
+```
+
+## Development
+
+Make sure to setup git config to handle the formatting/whitespaces correctly. To be able to work cross-platform,
+we upload all files in LF format. If you work on a windows machine, the default format is CRLF.
+
+```sh
+# On Windows:
+git config --global core.autocrlf true
+# On Linux/Mac:
+git config --global core.autocrlf input
+```
+
+To turn off the warning (not the functionality), run:
+
+```sh
+$ git config --global core.safecrlf false
+```
+
+Install the project in editable mode and with development requirements:
+```
+pip install -e .[dev]
+```
+
+### Initialize pre-comit git hooks (on first setup)
+
+This is only required once when you start to work on the code.
+
+```
+pre-commit install
+```
+
+### Versioning
+
+Versioning is done via continuous integration (CI) pipelines also known as GitHub Actions. Currently, the pipeline is
+triggered on every commit. It reads the version from `version.json` file (that must be in format `MAJOR.MINOR`) and
+adds a build number to it, so it becomes `MAJOR.MINOR.BUILD`. The build number is simply the counter of pipeline runs.
+This means that if you re-run the pipeline, you will get a version increase.
+
+### GitHub Actions
+
+There is one pipeline/action that runs on every commit. It increases a version number of the package, builds wheel
+and msi distributables. These distributable files are available in form of an artifact. It is possible to download them
+as a single .zip archive. See for example [this](https://github.com/kavli-ntnu/npx-compress/suites/5878773778/artifacts/198596214).
+
+### Making standalone executables
+
+[cx_Freeze](https://cx-freeze.readthedocs.io/en/latest/) may be used to create standalone executable packages for different
+platforms. It's up to you to create virtual environment with cx_Freeze in it. See [original documentation](https://cx-freeze.readthedocs.io/en/latest/installation.html) for details.
+
+In general, you should prepare the python environment on your build
+machine before using cx_Freeze. Run in Python >=3.7:
+```
+python -m pip install --upgrade pip build cx_freeze trove-classifiers
+pip install .
+```
+
+For example, one may create .msi package for usage under Windows:
+```
+python setup_cx.py bdist_msi
+```
+
+Created `.msi` file will be in `dist` folder. You are encouraged to use github actions in order to build .msi packages.


### PR DESCRIPTION
Bugfixes:

* Fix for forcing `--dry-run` and `--decompress` to always be False
* Fix for `--dry-run` not being a dry run sometimes
* Prevent source-file deletion during dry-run
* Prevent source-file deletion if compression/decompression failed

Changes
* Introduce `-k`, `--keep-original` flag to leave source files intact (should be useful if users need to decompress a file to do some work but want to keep the decompressed file for return to storage afterwards)
* Cleanup broken output-file if compression/decompression failed
* Move the developer-specific documentation into a separate file
* Improve documentation with worked examples for less technically-confident users